### PR TITLE
Fix port-agnostic asset URLs to prevent Next.js port conflicts

### DIFF
--- a/interfaces/mcp-server/cli_wrapper.py
+++ b/interfaces/mcp-server/cli_wrapper.py
@@ -124,7 +124,7 @@ def enhanced_search(query: str, asset_data: Dict, patterns: Dict) -> Dict[str, A
     if should_include_ciq:
         ciq_logos = {
             "horizontal_black": {
-                "url": "http://localhost:3000/assets/global/CIQ_logos/CIQ_logo_1clr_lightmode.svg",
+                "url": "/assets/global/CIQ_logos/CIQ_logo_1clr_lightmode.svg",
                 "filename": "CIQ_logo_1clr_lightmode.svg",
                 "background": "light",
                 "color": "black",

--- a/interfaces/mcp-server/metadata/asset-inventory.json
+++ b/interfaces/mcp-server/metadata/asset-inventory.json
@@ -2,7 +2,7 @@
   "assets": {
     "ascender": {
       "horizontal_black": {
-        "url": "http://localhost:3000/assets/products/ascender/logos/AscenderPro_logo_h-blk.svg",
+        "url": "/assets/products/ascender/logos/AscenderPro_logo_h-blk.svg",
         "filename": "AscenderPro_logo_h-blk.svg",
         "background": "light",
         "color": "black",
@@ -14,7 +14,7 @@
         ]
       },
       "vertical_black": {
-        "url": "http://localhost:3000/assets/products/ascender/logos/AscenderPro_logo_v-blk.svg",
+        "url": "/assets/products/ascender/logos/AscenderPro_logo_v-blk.svg",
         "filename": "AscenderPro_logo_v-blk.svg",
         "background": "light",
         "color": "black",
@@ -27,7 +27,7 @@
         ]
       },
       "symbol_black": {
-        "url": "http://localhost:3000/assets/products/ascender/logos/AscenderPro_logo_symbol-blk.svg",
+        "url": "/assets/products/ascender/logos/AscenderPro_logo_symbol-blk.svg",
         "filename": "AscenderPro_logo_symbol-blk.svg",
         "background": "light",
         "color": "black",
@@ -39,7 +39,7 @@
     },
     "rlc-hardened": {
       "vertical_black": {
-        "url": "http://localhost:3000/assets/products/rlc-hardened/logos/RLC-H_logo_v-blk.svg",
+        "url": "/assets/products/rlc-hardened/logos/RLC-H_logo_v-blk.svg",
         "filename": "RLC-H_logo_v-blk.svg",
         "background": "light",
         "color": "black",
@@ -52,7 +52,7 @@
         ]
       },
       "symbol_black": {
-        "url": "http://localhost:3000/assets/products/rlc-hardened/logos/RLC-H_logo_symbol-blk.svg",
+        "url": "/assets/products/rlc-hardened/logos/RLC-H_logo_symbol-blk.svg",
         "filename": "RLC-H_logo_symbol-blk.svg",
         "background": "light",
         "color": "black",
@@ -62,7 +62,7 @@
         "tags": []
       },
       "horizontal_black": {
-        "url": "http://localhost:3000/assets/products/rlc-hardened/logos/RLC-H_logo_h-blk.svg",
+        "url": "/assets/products/rlc-hardened/logos/RLC-H_logo_h-blk.svg",
         "filename": "RLC-H_logo_h-blk.svg",
         "background": "light",
         "color": "black",
@@ -76,7 +76,7 @@
     },
     "warewulf": {
       "vertical_black": {
-        "url": "http://localhost:3000/assets/products/warewulf/logos/WarewulfPro_logo_v-blk.svg",
+        "url": "/assets/products/warewulf/logos/WarewulfPro_logo_v-blk.svg",
         "filename": "WarewulfPro_logo_v-blk.svg",
         "background": "light",
         "color": "black",
@@ -89,7 +89,7 @@
         ]
       },
       "symbol_black": {
-        "url": "http://localhost:3000/assets/products/warewulf/logos/WarewulfPro_logo_symbol-blk.svg",
+        "url": "/assets/products/warewulf/logos/WarewulfPro_logo_symbol-blk.svg",
         "filename": "WarewulfPro_logo_symbol-blk.svg",
         "background": "light",
         "color": "black",
@@ -99,7 +99,7 @@
         "tags": []
       },
       "horizontal_black": {
-        "url": "http://localhost:3000/assets/products/warewulf/logos/WarewulfPro_logo_h-blk.svg",
+        "url": "/assets/products/warewulf/logos/WarewulfPro_logo_h-blk.svg",
         "filename": "WarewulfPro_logo_h-blk.svg",
         "background": "light",
         "color": "black",
@@ -113,7 +113,7 @@
     },
     "fuzzball": {
       "horizontal_black": {
-        "url": "http://localhost:3000/assets/products/fuzzball/logos/Fuzzball_logo_h-blk.svg",
+        "url": "/assets/products/fuzzball/logos/Fuzzball_logo_h-blk.svg",
         "filename": "Fuzzball_logo_h-blk.svg",
         "background": "light",
         "color": "black",
@@ -125,7 +125,7 @@
         ]
       },
       "symbol_black": {
-        "url": "http://localhost:3000/assets/products/fuzzball/logos/Fuzzball_logo_symbol-blk.svg",
+        "url": "/assets/products/fuzzball/logos/Fuzzball_logo_symbol-blk.svg",
         "filename": "Fuzzball_logo_symbol-blk.svg",
         "background": "light",
         "color": "black",
@@ -135,7 +135,7 @@
         "tags": []
       },
       "vertical_black": {
-        "url": "http://localhost:3000/assets/products/fuzzball/logos/Fuzzball_logo_v-blk.svg",
+        "url": "/assets/products/fuzzball/logos/Fuzzball_logo_v-blk.svg",
         "filename": "Fuzzball_logo_v-blk.svg",
         "background": "light",
         "color": "black",

--- a/interfaces/web-gui/src/lib/brandAssetsService.ts
+++ b/interfaces/web-gui/src/lib/brandAssetsService.ts
@@ -77,8 +77,8 @@ function transformCLIResult(cliResult: any, showPreferredOnly: boolean = true): 
         title: asset.filename?.replace(/\.[^/.]+$/, "") || "Unknown Asset",
         displayName: `${product.toUpperCase()} Logo`,
         description: `${product} ${asset.type} - ${asset.layout}`,
-        url: asset.url.replace('localhost:3000', 'localhost:3005'), // Fix URL
-        thumbnailUrl: asset.url.replace('localhost:3000', 'localhost:3005'),
+        url: asset.url, // Use URL as-is (now relative)
+        thumbnailUrl: asset.url,
         fileType: asset.filename ? asset.filename.split('.').pop()?.toLowerCase() || 'svg' : 'svg',
         dimensions: { width: 100, height: 100 },
         tags: asset.tags || [],
@@ -100,8 +100,8 @@ function transformCLIResult(cliResult: any, showPreferredOnly: boolean = true): 
           title: `${asset.filename?.replace(/\.[^/.]+$/, "") || "Unknown Asset"} (Dark)`,
           displayName: `${product.toUpperCase()} Logo (Dark)`,
           description: `${product} ${asset.type} - ${asset.layout} (dark mode)`,
-          url: asset.url.replace('localhost:3000', 'localhost:3005'),
-          thumbnailUrl: asset.url.replace('localhost:3000', 'localhost:3005'),
+          url: asset.url, // Use URL as-is (now relative)
+          thumbnailUrl: asset.url,
           fileType: asset.filename ? asset.filename.split('.').pop()?.toLowerCase() || 'svg' : 'svg',
           dimensions: { width: 100, height: 100 },
           tags: [...(asset.tags || []), 'dark-mode'],


### PR DESCRIPTION
• Convert all hardcoded localhost:3000 URLs to relative paths in asset-inventory.json • Update cli_wrapper.py CIQ logo URL to use relative path • Remove port conversion logic from brandAssetsService.ts • Assets now load correctly regardless of Next.js port assignment

This resolves the issue where assets failed to load when Next.js runs on different ports (3000, 3001, 3006, etc.) due to port conflicts from multiple development server instances.

Benefits:
- Works on any port Next.js chooses automatically
- No more hardcoded localhost URLs breaking across sessions
- Eliminates port-specific URL conversion hacks
- Future-proof against port conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)