### PR TITLE
Fix deployed version CIQ logo issue by adding to demo mode data

### DIFF
--- a/interfaces/mcp-server/metadata/asset-inventory.json
+++ b/interfaces/mcp-server/metadata/asset-inventory.json
@@ -184,6 +184,22 @@
           "stacked"
         ]
       }
+    },
+    "ciq": {
+      "horizontal_black": {
+        "url": "/assets/global/CIQ_logos/CIQ_logo_1clr_lightmode.svg",
+        "filename": "CIQ_logo_1clr_lightmode.svg",
+        "background": "light",
+        "color": "black",
+        "layout": "horizontal",
+        "type": "logo",
+        "size": "large",
+        "tags": [
+          "company",
+          "primary",
+          "general-use"
+        ]
+      }
     }
   },
   "rules": {
@@ -274,6 +290,7 @@
   "index": {
     "products": [
       "ascender",
+      "ciq",
       "fuzzball",
       "rlc-hardened",
       "rlc-ai",
@@ -296,7 +313,7 @@
       "tall_banner",
       "wide_format"
     ],
-    "total_assets": 15
+    "total_assets": 16
   },
   "colors": {
     "available": false,

--- a/interfaces/web-gui/src/data/asset-inventory.json
+++ b/interfaces/web-gui/src/data/asset-inventory.json
@@ -184,6 +184,22 @@
           "stacked"
         ]
       }
+    },
+    "ciq": {
+      "horizontal_black": {
+        "url": "/assets/global/CIQ_logos/CIQ_logo_1clr_lightmode.svg",
+        "filename": "CIQ_logo_1clr_lightmode.svg",
+        "background": "light",
+        "color": "black",
+        "layout": "horizontal",
+        "type": "logo",
+        "size": "large",
+        "tags": [
+          "company",
+          "primary",
+          "general-use"
+        ]
+      }
     }
   },
   "rules": {
@@ -274,6 +290,7 @@
   "index": {
     "products": [
       "ascender",
+      "ciq",
       "fuzzball",
       "rlc-hardened",
       "rlc-ai",
@@ -296,7 +313,7 @@
       "tall_banner",
       "wide_format"
     ],
-    "total_assets": 15
+    "total_assets": 16
   },
   "colors": {
     "available": false,


### PR DESCRIPTION
- Add CIQ company logo entry to both MCP server and web-GUI asset inventories
- Update products lists and total_assets counts from 15→16
- Document demo mode vs unified backend inconsistency in CLAUDE.md
- Include critical asset addition checklist to prevent future deployment issues

Fixes missing CIQ logo on deployed version which uses demo mode data files instead of unified CLI backend. Local development was working due to hardcoded CIQ logic in cli_wrapper.py.

🤖 Generated with [Claude Code](https://claude.ai/code)