### PR TITLE
Implement width-based sizing system with enhanced custom width support

### DIFF
--- a/interfaces/web-gui/src/components/DownloadModal.tsx
+++ b/interfaces/web-gui/src/components/DownloadModal.tsx
@@ -5,6 +5,7 @@ import { Asset } from '@/types/asset';
 import { X, Download, FileImage, FileText, Monitor, Sun, Moon } from 'lucide-react';
 import { convertSvgToRaster, isSvgUrl, getFileExtension } from '@/lib/svgConverter';
 import { manipulateSvgColors, BRAND_COLORS } from '@/lib/svgColorTest';
+import { SIZE_PRESETS, DEFAULT_SIZE, getSizePixels, CUSTOM_SIZE_CONSTRAINTS, validateCustomSize } from '@/lib/sizeConstants';
 
 interface DownloadModalProps {
   asset: Asset;
@@ -13,17 +14,14 @@ interface DownloadModalProps {
 }
 
 type FormatType = 'svg' | 'png' | 'jpeg';
-type SizePreset = 'S' | 'M' | 'L' | 'custom';
+type SizePreset = 'S' | 'M' | 'L' | 'custom width';
 type LogoVariant = 'horizontal' | 'vertical' | 'symbol';
 type BackgroundMode = 'light' | 'dark';
 type ColorMode = '1-color' | '2-color';
 type BrandColor = 'black' | 'white' | 'brand-green' | 'dark-green';
 
-const SIZE_PRESETS = {
-  S: 256,
-  M: 512, 
-  L: 1024
-};
+// Size presets now imported from centralized constants
+// S: 512px, M: 1024px, L: 2048px width-based sizing
 
 const LOGO_VARIANTS = {
   horizontal: { label: 'Horizontal', desc: 'Wide layout' },
@@ -53,8 +51,8 @@ export default function DownloadModal({ asset, isOpen, onClose }: DownloadModalP
   const [colorMode, setColorMode] = useState<ColorMode>('1-color');
   const [selectedColor, setSelectedColor] = useState<BrandColor>('black');
   const [selectedFormat, setSelectedFormat] = useState<FormatType>(isOriginalSvg ? 'svg' : 'png');
-  const [selectedSize, setSelectedSize] = useState<SizePreset>('M');
-  const [customSize, setCustomSize] = useState<string>('512');
+  const [selectedSize, setSelectedSize] = useState<SizePreset>(DEFAULT_SIZE);
+  const [customSize, setCustomSize] = useState<string>(CUSTOM_SIZE_CONSTRAINTS.default.toString());
   const [isDownloading, setIsDownloading] = useState(false);
   
   // Preview state with caching
@@ -125,10 +123,7 @@ export default function DownloadModal({ asset, isOpen, onClose }: DownloadModalP
   };
 
   const getSizeInPixels = () => {
-    if (selectedSize === 'custom') {
-      return parseInt(customSize) || 512;
-    }
-    return SIZE_PRESETS[selectedSize];
+    return getSizePixels(selectedSize === 'custom width' ? 'Custom Width' : selectedSize, customSize);
   };
 
   const generateFileName = () => {
@@ -523,7 +518,7 @@ export default function DownloadModal({ asset, isOpen, onClose }: DownloadModalP
               Size
             </label>
             <div className="grid grid-cols-4 gap-2 mb-2">
-              {(Object.keys(SIZE_PRESETS) as SizePreset[]).map((size) => (
+              {(['S', 'M', 'L', 'custom width'] as SizePreset[]).map((size) => (
                 <button
                   key={size}
                   onClick={() => setSelectedSize(size)}
@@ -557,7 +552,7 @@ export default function DownloadModal({ asset, isOpen, onClose }: DownloadModalP
               </button>
             </div>
             
-            {selectedSize === 'custom' && (
+            {selectedSize === 'custom width' && (
               <div className="flex items-center gap-2 mt-1">
                 <input
                   type="number"

--- a/interfaces/web-gui/src/lib/productDefaults.ts
+++ b/interfaces/web-gui/src/lib/productDefaults.ts
@@ -3,6 +3,8 @@
  * YOU define what users get with "Quick Download" - no AI, no complexity
  */
 
+import { DEFAULT_SIZE_PIXELS } from './sizeConstants';
+
 export interface ProductDefaults {
   variant: 'horizontal' | 'vertical' | 'symbol';
   format: 'svg' | 'png' | 'jpeg';
@@ -70,7 +72,7 @@ export const PRODUCT_DEFAULTS: Record<string, ProductDefaults> = {
   ciq: {
     variant: 'horizontal', // Not used for CIQ, but required by interface
     format: 'png',
-    size: 512,
+    size: DEFAULT_SIZE_PIXELS,
     colorMode: 'light', // Maps to light-mode for CIQ
     reason: 'Standard business logo for general use'
   },
@@ -79,7 +81,7 @@ export const PRODUCT_DEFAULTS: Record<string, ProductDefaults> = {
   fuzzball: {
     variant: 'horizontal',      // Most versatile for presentations, headers
     format: 'png',              // Universal compatibility
-    size: 512,                  // Good balance of quality vs file size
+    size: DEFAULT_SIZE_PIXELS,                  // Good balance of quality vs file size
     colorMode: 'dark',          // Works on most light backgrounds
     reason: 'Optimized for presentations and general business use'
   },
@@ -87,7 +89,7 @@ export const PRODUCT_DEFAULTS: Record<string, ProductDefaults> = {
   ascender: {
     variant: 'horizontal',      // Professional layout for business contexts
     format: 'png',              // Broad compatibility
-    size: 512,                  // Standard resolution
+    size: DEFAULT_SIZE_PIXELS,                  // Standard resolution
     colorMode: 'dark',          // Professional appearance
     reason: 'Professional standard for technical documentation'
   },
@@ -95,7 +97,7 @@ export const PRODUCT_DEFAULTS: Record<string, ProductDefaults> = {
   warewulf: {
     variant: 'horizontal',      // Consistent with other products
     format: 'png',              // Safe choice for compatibility  
-    size: 512,                  // Balanced size
+    size: DEFAULT_SIZE_PIXELS,                  // Balanced size
     colorMode: 'dark',          // Clear on light backgrounds
     reason: 'Versatile for technical presentations and documentation'
   },
@@ -103,7 +105,7 @@ export const PRODUCT_DEFAULTS: Record<string, ProductDefaults> = {
   'rlc-hardened': {
     variant: 'horizontal',      // Consistent with other products
     format: 'png',              // Safe choice for compatibility  
-    size: 512,                  // Balanced size
+    size: DEFAULT_SIZE_PIXELS,                  // Balanced size
     colorMode: 'dark',          // Clear on light backgrounds
     reason: 'Enterprise-grade for security-focused presentations'
   },
@@ -112,11 +114,14 @@ export const PRODUCT_DEFAULTS: Record<string, ProductDefaults> = {
   default: {
     variant: 'horizontal',      // Safest choice for most contexts
     format: 'png',              // Most compatible format
-    size: 512,                  // Reasonable balance
+    size: DEFAULT_SIZE_PIXELS,                  // Reasonable balance
     colorMode: 'dark',          // Works on most backgrounds
     reason: 'General-purpose configuration for business use'
   }
 };
+
+// Note: All sizes now use centralized DEFAULT_SIZE_PIXELS (1024px) from sizeConstants
+// This ensures consistency with the new S-512px, M-1024px, L-2048px sizing system
 
 /**
  * Get product defaults with fallback

--- a/interfaces/web-gui/src/lib/sizeConstants.ts
+++ b/interfaces/web-gui/src/lib/sizeConstants.ts
@@ -1,0 +1,93 @@
+/**
+ * Centralized size constants for brand asset downloads
+ * 
+ * Width-based sizing system with fixed aspect ratios:
+ * - S: 512px width (Small)
+ * - M: 1024px width (Medium) - Default
+ * - L: 2048px width (Large)
+ * 
+ * All assets maintain their original aspect ratios.
+ * Height is calculated automatically based on width.
+ */
+
+export type SizeChoice = 'S' | 'M' | 'L' | 'Custom Width';
+
+// Width-based size presets (pixels)
+export const SIZE_PRESETS = {
+  S: 512,   // Small: 512px width
+  M: 1024,  // Medium: 1024px width (default)
+  L: 2048   // Large: 2048px width
+} as const;
+
+// Default size choice
+export const DEFAULT_SIZE: SizeChoice = 'M';
+
+// Default pixel value for quick downloads and fallbacks
+export const DEFAULT_SIZE_PIXELS = SIZE_PRESETS[DEFAULT_SIZE];
+
+// Size choice display labels
+export const SIZE_LABELS = {
+  S: 'Small (512px)',
+  M: 'Medium (1024px)', 
+  L: 'Large (2048px)',
+  'Custom Width': 'Custom Width'
+} as const;
+
+// Custom size constraints
+export const CUSTOM_SIZE_CONSTRAINTS = {
+  min: 50,    // Minimum custom size
+  max: 5000,  // Maximum custom size (reasonable range for logos)
+  default: DEFAULT_SIZE_PIXELS
+} as const;
+
+// Helper function to get pixel value for any size choice
+export function getSizePixels(choice: SizeChoice, customValue?: string | number): number {
+  if (choice === 'Custom Width') {
+    const customPixels = typeof customValue === 'string' 
+      ? parseInt(customValue) 
+      : customValue;
+    
+    // Return parsed value if valid, otherwise fallback to default
+    if (!customPixels || isNaN(customPixels) || customPixels < CUSTOM_SIZE_CONSTRAINTS.min || customPixels > CUSTOM_SIZE_CONSTRAINTS.max) {
+      return CUSTOM_SIZE_CONSTRAINTS.default;
+    }
+    
+    return customPixels;
+  }
+  
+  return SIZE_PRESETS[choice];
+}
+
+// Helper function to validate custom size and get error message
+export function validateCustomSize(value: string | number): { isValid: boolean; errorMessage?: string } {
+  const pixels = typeof value === 'string' ? parseInt(value) : value;
+  
+  if (!pixels || isNaN(pixels)) {
+    return {
+      isValid: false,
+      errorMessage: `Size not supported, choose a range between ${CUSTOM_SIZE_CONSTRAINTS.min}-${CUSTOM_SIZE_CONSTRAINTS.max}px`
+    };
+  }
+  
+  if (pixels < CUSTOM_SIZE_CONSTRAINTS.min || pixels > CUSTOM_SIZE_CONSTRAINTS.max) {
+    return {
+      isValid: false,
+      errorMessage: `Size not supported, choose a range between ${CUSTOM_SIZE_CONSTRAINTS.min}-${CUSTOM_SIZE_CONSTRAINTS.max}px`
+    };
+  }
+  
+  return { isValid: true };
+}
+
+// Helper function to get size choice from pixel value (for reverse lookup)
+export function getSizeChoiceFromPixels(pixels: number): SizeChoice {
+  // Find exact match first
+  for (const [key, value] of Object.entries(SIZE_PRESETS)) {
+    if (value === pixels) {
+      return key as SizeChoice;
+    }
+  }
+  
+  // No exact match, return Custom Width
+  return 'Custom Width';
+}


### PR DESCRIPTION
- Replace height-based sizing with width-based system (S-512px, M-1024px, L-2048px)
- Add centralized sizeConstants.ts for unified architecture consistency
- Update both DownloadModal components to use width-based scaling
- Implement custom width validation with 50-5000px range and error messaging
- Change "Custom" to "Custom Width" for clarity across interfaces
- Update productDefaults.ts to use centralized DEFAULT_SIZE_PIXELS (1024px)
- Maintain aspect ratio preservation during SVG scaling
- Ensure consistency across MCP, Web UI, local and deployed versions

🤖 Generated with [Claude Code](https://claude.ai/code)