### PR TITLE
Fix CIQ logo 2-color SVG download bug

### DIFF
--- a/interfaces/web-gui/src/components/DownloadModalNew.tsx
+++ b/interfaces/web-gui/src/components/DownloadModalNew.tsx
@@ -258,10 +258,16 @@ export default function DownloadModalNew({ asset, isOpen, onClose }: DownloadMod
       let blob: Blob;
       
       if (assetType === 'svg') {
-        // SVG download
-        const response = await fetch(asset.url);
-        let svgContent = await response.text();
+        // SVG download - use correct variant URL like raster downloads
+        const selectedVariantData = variants.find(v => v.id === selectedVariant);
+        const sourceUrl = selectedVariantData?.logoPath || asset.url;
+        console.log('SVG download variant:', selectedVariant, 'from URL:', sourceUrl);
         
+        const response = await fetch(sourceUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch SVG: ${response.status} ${response.statusText}`);
+        }
+        const svgContent = await response.text();
         
         blob = new Blob([svgContent], { type: 'image/svg+xml' });
       } else {

--- a/test_ciq_logo_variants.html
+++ b/test_ciq_logo_variants.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CIQ Logo Variant Test - MARK FOR DELETION</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; }
+        .test-case { 
+            border: 1px solid #ccc; 
+            margin: 10px; 
+            padding: 15px; 
+            border-radius: 5px;
+        }
+        .variant-urls {
+            background: #f0f0f0;
+            padding: 10px;
+            margin: 10px 0;
+            font-family: monospace;
+            font-size: 12px;
+        }
+        h1 { color: #333; }
+        h3 { color: #666; }
+        .status { font-weight: bold; }
+        .pass { color: green; }
+        .fail { color: red; }
+    </style>
+</head>
+<body>
+    <h1>🧪 CIQ Logo Variant Test</h1>
+    <p><strong>PURPOSE:</strong> Test CIQ logo variant selection for SVG downloads after bug fix</p>
+    <p><strong>MARK FOR DELETION:</strong> This is a temporary test file created for bug verification</p>
+    
+    <div class="test-case">
+        <h3>Expected CIQ Logo Variant URLs:</h3>
+        <div class="variant-urls">
+            1-color light mode: /assets/global/CIQ_logos/CIQ_logo_1clr_lightmode.svg<br>
+            2-color light mode: /assets/global/CIQ_logos/CIQ_logo_2clr_lightmode.svg<br>
+            1-color dark mode: /assets/global/CIQ_logos/CIQ_logo_1clr_darkmode.svg<br>
+            2-color dark mode: /assets/global/CIQ_logos/CIQ_logo_2clr_darkmode.svg
+        </div>
+    </div>
+    
+    <div class="test-case">
+        <h3>Test Procedure:</h3>
+        <ol>
+            <li>Go to web app and search for "ciq"</li>
+            <li>Open CIQ logo in modal</li>
+            <li>Test each combination:
+                <ul>
+                    <li>Light mode + 1-color + SVG download</li>
+                    <li>Light mode + 2-color + SVG download ⚠️ <strong>(This was the bug)</strong></li>
+                    <li>Dark mode + 1-color + SVG download</li>
+                    <li>Dark mode + 2-color + SVG download ⚠️ <strong>(This was the bug)</strong></li>
+                </ul>
+            </li>
+            <li>Check browser dev tools network tab to see which URL was fetched</li>
+            <li>Verify downloaded SVG matches selected variant</li>
+        </ol>
+    </div>
+    
+    <div class="test-case">
+        <h3>🔧 Bug Fix Applied:</h3>
+        <p>Updated SVG download logic in DownloadModalNew.tsx to use variant selection:</p>
+        <div class="variant-urls">
+            // OLD CODE (BUG):
+            const response = await fetch(asset.url); // Always used base asset URL
+            
+            // NEW CODE (FIXED):
+            const selectedVariantData = variants.find(v => v.id === selectedVariant);
+            const sourceUrl = selectedVariantData?.logoPath || asset.url; // Uses variant logoPath
+            const response = await fetch(sourceUrl);
+        </div>
+    </div>
+    
+    <div class="test-case">
+        <h3>Manual Testing Results:</h3>
+        <div id="test-results">
+            <p><em>To be filled in manually during testing...</em></p>
+            <div class="status">
+                ⚪ Light mode + 1-color + SVG: <span id="test1">Not tested</span><br>
+                ⚪ Light mode + 2-color + SVG: <span id="test2">Not tested</span><br>
+                ⚪ Dark mode + 1-color + SVG: <span id="test3">Not tested</span><br>
+                ⚪ Dark mode + 2-color + SVG: <span id="test4">Not tested</span><br>
+                ⚪ Non-CIQ assets still work: <span id="test5">Not tested</span>
+            </div>
+        </div>
+    </div>
+    
+    <div class="test-case">
+        <h3>🗑️ Cleanup Note:</h3>
+        <p><strong>This file should be deleted after testing is complete.</strong></p>
+        <p>Command: <code>rm test_ciq_logo_variants.html</code></p>
+    </div>
+    
+    <script>
+        console.log('🧪 CIQ Logo Variant Test Page Loaded');
+        console.log('Expected variant URLs:');
+        console.log('1-color light:', '/assets/global/CIQ_logos/CIQ_logo_1clr_lightmode.svg');
+        console.log('2-color light:', '/assets/global/CIQ_logos/CIQ_logo_2clr_lightmode.svg');
+        console.log('1-color dark:', '/assets/global/CIQ_logos/CIQ_logo_1clr_darkmode.svg');
+        console.log('2-color dark:', '/assets/global/CIQ_logos/CIQ_logo_2clr_darkmode.svg');
+    </script>
+</body>
+</html>


### PR DESCRIPTION
BUG: CIQ logo SVG downloads always returned 1-color variant regardless of user selection. PNG and JPEG downloads worked correctly, but SVG downloads ignored variant selection.

ROOT CAUSE: SVG download logic used base asset.url instead of selected variant's logoPath, while raster downloads correctly used variant selection logic.

FIX: Apply same variant selection logic to SVG downloads as raster downloads:
- Use selectedVariantData.find() to get correct variant
- Use selectedVariantData?.logoPath || asset.url for source URL
- Add error handling and logging for SVG fetching
- Fix TypeScript prefer-const linting issue

IMPACT: Now correctly downloads the selected CIQ variant:
- Light mode + 2-color + SVG → CIQ_logo_2clr_lightmode.svg ✅ (was broken)
- Dark mode + 2-color + SVG → CIQ_logo_2clr_darkmode.svg ✅ (was broken)
- Other variants and product logos preserved ✅

Added test file for manual verification: test_ciq_logo_variants.html

🤖 Generated with [Claude Code](https://claude.ai/code)